### PR TITLE
Ignore psycasts during shield block

### DIFF
--- a/Source/1.2/Shields/Harmony/Harmony_Verb.cs
+++ b/Source/1.2/Shields/Harmony/Harmony_Verb.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using FrontierDevelopments.General;
 using HarmonyLib;
 using Verse;
+using RimWorld;
 
 namespace FrontierDevelopments.Shields.Harmony
 {
@@ -18,6 +19,7 @@ namespace FrontierDevelopments.Shields.Harmony
 
         protected static bool ShieldBlocks(Thing caster, Verb verb, IntVec3 source, LocalTargetInfo target)
         {
+            if (verb.GetType() == typeof(Verb_CastPsycast)) return false;
             if (!Mod.Settings.EnableAIVerbFindShotLine) return false;
             if (!verb.verbProps.requireLineOfSight) return false;
             if (UncheckedTypes.Exists(a => a.IsInstanceOfType(verb))) return false;


### PR DESCRIPTION
Quickly fixes #130
May not be the intended behaviour, but works fine.